### PR TITLE
Added QSBR

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2015 Edward Kmett
+Copyright 2015 Edward Kmett and Ted Cooper
 
 All rights reserved.
 

--- a/README.markdown
+++ b/README.markdown
@@ -2,12 +2,19 @@
 
 [![Build Status](https://secure.travis-ci.org/ekmett/rcu.png?branch=master)](http://travis-ci.org/ekmett/rcu)
 
-This package is an exploration of read-copy-update in Haskell based loosely on the API in [Relativistic Programming in Haskell](http://web.cecs.pdx.edu/~walpole/papers/haskell2015.pdf) by Cooper and Walpole, but converted to using STM in the spirit of Howard and Walpole.
+This package is an exploration of Read-Copy Update in Haskell based on [Relativistic Programming in Haskell](http://web.cecs.pdx.edu/~walpole/papers/haskell2015.pdf) by Cooper and Walpole.  It includes STM- and QSBR-based implementations.
+
+In the spirit of [A Relativistic Enhancement to Software Transactional Memory](https://www.usenix.org/legacy/events/hotpar11/tech/final_files/Howard.pdf)
+ by Howard and Walpole, we could extend the STM implementation to allow reads and
+writes on the same data in parallel, writes to disjoint data in parallel, and
+force readers to agree that writes before a `synchronize` happened before
+writes after it.
 
 ## Contact Information
 
 Contributions and bug reports are welcome!
 
-Please feel free to contact me through github or on the #haskell IRC channel on irc.freenode.net.
+Please feel free to contact us through github or on the #haskell IRC channel on irc.freenode.net.
 
 -Edward Kmett
+-Ted Cooper

--- a/examples/MoveStringSTM.hs
+++ b/examples/MoveStringSTM.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE FlexibleContexts #-}
+import Control.Concurrent.MVar (takeMVar)
+import Control.Concurrent.RCU.STM
+import Control.Concurrent.RCU.Class
+import Control.Monad (forM, forM_, replicateM)
+import Data.List (group, intercalate)
+import Debug.Trace (trace)
+import Prelude hiding (read)
+
+data List s a = Nil | Cons a (SRef s (List s a))
+
+snapshot :: MonadReading (SRef s) (m s) => [a] -> List s a -> m s [a]
+snapshot acc Nil         = return $ reverse acc
+snapshot acc (Cons x rn) = snapshot (x : acc) =<< readSRef rn
+
+reader :: Int -> [[a]] -> SRef s (List s a) -> RCU s [[a]]
+reader 0 acc _    = return $ reverse acc
+reader n acc head = do
+  l <- reading $ snapshot [] =<< readSRef head
+  reader (n - 1) (l : acc) head
+
+deleteMiddle :: SRef s (List s a) -> WritingRCU s ()
+deleteMiddle rl = do
+  Cons a rn <- readSRef rl
+  Cons _ rm <- readSRef rn
+  writeSRef rl $ Cons a rm 
+
+moveDback :: SRef s (List s Char) -> WritingRCU s ()
+moveDback rl = do
+  Cons a rb <- readSRef rl
+  Cons b rc <- readSRef rb
+  -- duplicate pointer to B
+  rb'       <- copySRef rb
+  Cons c rd <- readSRef rc
+  ne        <- readSRef rd
+  -- link in a new C after A
+  writeSRef rb $ Cons c rb'
+  -- any reader who starts during this grace period 
+  -- sees either "ABCDE" or "ACBCDE"
+  synchronize
+  -- unlink the old C
+  writeSRef rc ne
+
+testList :: RCU s (SRef s (List s Char))
+testList = do
+  tail <- newSRef Nil
+  c1   <- newSRef $ Cons 'E' tail
+  c2   <- newSRef $ Cons 'D' c1
+  c3   <- newSRef $ Cons 'C' c2
+  c4   <- newSRef $ Cons 'B' c3
+  newSRef $ Cons 'A' c4
+
+compactShow :: (Show a, Eq a) => [a] -> String
+compactShow xs = intercalate ", " $ map (\xs -> show (length xs) ++ " x " ++ show (head xs)) $ group xs
+
+main :: IO ()
+main = do 
+  outs <- runRCU $ do
+    -- initialize list
+    head <- testList
+    -- spawn 8 readers, each records 100000 snapshots of the list
+    rts <- replicateM 8 $ forking $ reader 100000 [] head
+    -- spawn a writer to move a node from a later position to an earlier position
+    wt  <- forking $ writing $ moveDback head
+    
+    -- wait for the readers to finish and print snapshots
+    outs <- forM rts $ \rt -> do 
+      v <- joining rt
+      return $ show (rcuThreadId rt) ++ ": " ++ compactShow v
+    -- wait for the writer to finish
+    joining wt
+    return outs
+  forM_ outs putStrLn

--- a/rcu.cabal
+++ b/rcu.cabal
@@ -4,16 +4,16 @@ version:       0.1
 license:       BSD3
 cabal-version: >= 1.22
 license-file:  LICENSE
-author:        Edward A. Kmett
-maintainer:    Edward A. Kmett <ekmett@gmail.com>
+author:        Edward A. Kmett, Ted Cooper
+maintainer:    Edward A. Kmett <ekmett@gmail.com>, Ted Cooper <anthezium@gmail.com>
 stability:     provisional
 homepage:      http://github.com/ekmett/rcu/
 bug-reports:   http://github.com/ekmett/rcu/issues
-copyright:     Copyright (C) 2015 Edward A. Kmett
+copyright:     Copyright (C) 2015 Edward A. Kmett, Theodore Rhys Cooper
 build-type:    Custom
 tested-with:   GHC == 7.10.1, GHC == 7.10.2
-synopsis:      STM-based Read-Copy-Update
-description:   STM-based Read-Copy-Update
+synopsis:      STM- and QSBR-based implementations of Read-Copy-Update
+description:   STM- and QSBR-based implementations of Read-Copy-Update
 
 extra-source-files:
   examples/*.hs
@@ -38,26 +38,46 @@ library
   build-depends:
     base >= 4.8 && < 5,
     stm >= 2.4.4 && < 2.5,
-    transformers >= 0.4 && < 0.5
+    transformers >= 0.4 && < 0.5,
+    primitive,
+    atomic-primops 
 
   exposed-modules:
     Control.Concurrent.RCU.Class
     Control.Concurrent.RCU.STM
     Control.Concurrent.RCU.STM.Internal
+    Control.Concurrent.RCU.QSBR
+    Control.Concurrent.RCU.QSBR.Internal
 
   ghc-options: -Wall -fwarn-tabs
 
   hs-source-dirs: src
   default-language: Haskell2010
 
-executable MoveString 
-  main-is: MoveString.hs
+executable MoveStringSTM
+  main-is: MoveStringSTM.hs
   build-depends:
     base >= 4.8 && < 5,
     stm >= 2.4.4 && < 2.5,
     transformers >= 0.4 && < 0.5
   other-modules:
     Control.Concurrent.RCU.STM
+
+  hs-source-dirs: src, examples
+  ghc-options:
+    -threaded -Wall -fwarn-tabs
+    "-with-rtsopts=-N"
+  default-language: Haskell2010
+
+executable MoveStringQSBR
+  main-is: MoveStringQSBR.hs
+  build-depends:
+    base >= 4.8 && < 5,
+    stm >= 2.4.4 && < 2.5,
+    transformers >= 0.4 && < 0.5,
+    atomic-primops 
+  other-modules:
+    Control.Concurrent.RCU.QSBR
 
   hs-source-dirs: src, examples
   ghc-options:

--- a/src/Control/Concurrent/RCU/Class.hs
+++ b/src/Control/Concurrent/RCU/Class.hs
@@ -11,9 +11,10 @@
 {-# OPTIONS_HADDOCK not-home #-}
 -----------------------------------------------------------------------------
 -- |
--- Copyright   :  (C) 2015 Edward Kmett
+-- Copyright   :  (C) 2015 Edward Kmett and Ted Cooper
 -- License     :  BSD-style (see the file LICENSE)
 -- Maintainer  :  Edward Kmett <ekmett@gmail.com>
+--                Ted Cooper <anthezium@gmail.com>
 -- Stability   :  experimental
 -- Portability :  non-portable
 --
@@ -143,10 +144,10 @@ class
   type Thread m :: * -> *
 
   -- | Fork a thread
-  forking  :: m a -> m (Thread m a)
+  forking :: m a -> m (Thread m a)
 
   -- | Join a thread
-  joining  :: Thread m a -> m a
+  joining :: Thread m a -> m a
 
   -- | Run a read-side critical section
   reading :: Reading m a -> m a

--- a/src/Control/Concurrent/RCU/QSBR.hs
+++ b/src/Control/Concurrent/RCU/QSBR.hs
@@ -9,7 +9,7 @@
 -- Portability :  non-portable
 --
 -----------------------------------------------------------------------------
-module Control.Concurrent.RCU.STM
+module Control.Concurrent.RCU.QSBR
   ( SRef
   , RCU, runRCU
   , MonadNew(..)
@@ -23,4 +23,4 @@ module Control.Concurrent.RCU.STM
   ) where
 
 import Control.Concurrent.RCU.Class
-import Control.Concurrent.RCU.STM.Internal
+import Control.Concurrent.RCU.QSBR.Internal

--- a/src/Control/Concurrent/RCU/QSBR/Internal.hs
+++ b/src/Control/Concurrent/RCU/QSBR/Internal.hs
@@ -1,0 +1,341 @@
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# OPTIONS_HADDOCK not-home #-}
+-----------------------------------------------------------------------------
+-- |
+-- Copyright   :  (C) 2015 Edward Kmett and Ted Cooper
+-- License     :  BSD-style (see the file LICENSE)
+-- Maintainer  :  Edward Kmett <ekmett@gmail.com>, 
+--                Ted Cooper <anthezium@gmail.com>
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- QSBR-based RCU
+-----------------------------------------------------------------------------
+module Control.Concurrent.RCU.QSBR.Internal
+  ( SRef(..)
+  , RCUThread(..)
+  , RCU(..)
+  , runRCU
+  , ReadingRCU(..)
+  , WritingRCU(..)
+  ) where
+
+import Control.Applicative
+import Control.Concurrent
+import Control.Concurrent.RCU.Class
+import Control.Monad
+import Control.Monad.IO.Class
+import Data.Atomics 
+import Data.Coerce
+import Data.List
+import Data.IORef 
+import Data.Word
+import Debug.Trace
+import Prelude hiding (read, Read)
+
+--------------------------------------------------------------------------------
+-- * Shared References
+--------------------------------------------------------------------------------
+
+-- | Shared references
+newtype SRef s a = SRef { unSRef :: IORef a }
+  deriving Eq
+
+newSRefIO :: a -> IO (IORef a)
+newSRefIO = newIORef
+{-# INLINE newSRefIO #-}
+
+readSRefIO :: IORef a -> IO a
+readSRefIO = readIORef
+{-# INLINE readSRefIO #-}
+
+writeSRefIO :: IORef a -> a ->  IO ()
+writeSRefIO r !a = do a `seq` writeBarrier 
+                      writeIORef r a
+{-# INLINE writeSRefIO #-}
+
+--------------------------------------------------------------------------------
+-- * Shared state
+--------------------------------------------------------------------------------
+
+-- | Counter for causal ordering.
+type Counter = IORef Word64
+
+offline :: Word64
+offline = 0
+
+online :: Word64
+online  = 1
+
+counterInc :: Word64
+counterInc = 2 -- online threads will never overflow to 1
+
+newCounter :: IO Counter
+newCounter = newIORef online
+
+readCounter :: Counter -> IO Word64
+readCounter = readIORef
+{-# INLINE readCounter #-}
+
+writeCounter :: Counter -> Word64 -> IO ()
+writeCounter c !i = writeIORef c i
+{-# INLINE writeCounter #-}
+
+incCounter :: Counter -> IO Word64
+incCounter c = do !x <- succ <$> readIORef c
+                  writeCounter c x
+                  return x
+{-# INLINE incCounter #-}
+  
+
+-- | State for an RCU computation.
+data RCUState = RCUState
+  { rcuStateGlobalCounter   :: {-# UNPACK #-} !Counter
+  , rcuStateMyCounter       :: {-# UNPACK #-} !Counter  -- each thread's state gets its own counter
+  , rcuStateThreadCountersV :: {-# UNPACK #-} !(MVar [Counter])
+  , rcuStateWriterLockV     :: {-# UNPACK #-} !(MVar ())
+  }
+
+--------------------------------------------------------------------------------
+-- * Read-Side Critical Sections
+--------------------------------------------------------------------------------
+
+-- | This is the basic read-side critical section for an RCU computation
+newtype ReadingRCU s a = ReadingRCU { runReadingRCU :: RCUState -> IO a } 
+  deriving Functor
+
+instance Applicative (ReadingRCU s) where
+  pure a = ReadingRCU $ \ _ -> pure a
+  ReadingRCU mf <*> ReadingRCU ma = ReadingRCU $ \ s -> mf s <*> ma s
+
+instance Monad (ReadingRCU s) where
+  return a = ReadingRCU $ \ _ -> pure a
+  ReadingRCU m >>= f = ReadingRCU $ \ s -> do
+    a <- m s
+    runReadingRCU (f a) s
+  fail s = ReadingRCU $ \ _ -> fail s
+
+instance Alternative (ReadingRCU s) where
+  empty = ReadingRCU $ \ _ -> empty
+  ReadingRCU ma <|> ReadingRCU mb = ReadingRCU $ \s -> ma s <|> mb s
+
+instance MonadPlus (ReadingRCU s) where
+  mzero = ReadingRCU $ \ _ -> mzero
+  ReadingRCU ma `mplus` ReadingRCU mb = ReadingRCU $ \s -> ma s `mplus` mb s
+
+instance MonadNew (SRef s) (ReadingRCU s) where
+  newSRef a = ReadingRCU $ \_ -> SRef <$> newSRefIO a
+
+instance MonadReading (SRef s) (ReadingRCU s) where
+  readSRef (SRef r) = ReadingRCU $ \ _ -> readSRefIO r
+  {-# INLINE readSRef #-}
+
+--------------------------------------------------------------------------------
+-- * Write-Side Critical Sections
+--------------------------------------------------------------------------------
+
+-- | This is the basic write-side critical section for an RCU computation
+newtype WritingRCU s a = WritingRCU { runWritingRCU :: RCUState -> IO a }
+  deriving Functor
+
+instance Applicative (WritingRCU s) where
+  pure a = WritingRCU $ \ _ -> pure a
+  WritingRCU mf <*> WritingRCU ma = WritingRCU $ \ s -> mf s <*> ma s
+
+instance Monad (WritingRCU s) where
+  return a = WritingRCU $ \ _ -> pure a
+  WritingRCU m >>= f = WritingRCU $ \ s -> do
+    a <- m s
+    runWritingRCU (f a) s
+  fail s = WritingRCU $ \ _ -> fail s
+
+instance Alternative (WritingRCU s) where
+  empty = WritingRCU $ \ _ -> empty
+  WritingRCU ma <|> WritingRCU mb = WritingRCU $ \s -> ma s <|> mb s
+
+instance MonadPlus (WritingRCU s) where
+  mzero = WritingRCU $ \ _ -> mzero
+  WritingRCU ma `mplus` WritingRCU mb = WritingRCU $ \s -> ma s `mplus` mb s
+
+instance MonadNew (SRef s) (WritingRCU s) where
+  newSRef a = WritingRCU $ \_ -> SRef <$> newSRefIO a
+
+instance MonadReading (SRef s) (WritingRCU s) where
+  readSRef (SRef r) = WritingRCU $ \ _ -> readSRefIO r
+  {-# INLINE readSRef #-}
+
+instance MonadWriting (SRef s) (WritingRCU s) where
+  writeSRef (SRef r) a = WritingRCU $ \ _ -> writeSRefIO r a
+  {-# INLINE writeSRef #-}
+  synchronize = WritingRCU synchronizeIO
+
+synchronizeIO :: RCUState -> IO () 
+synchronizeIO RCUState { rcuStateGlobalCounter
+                       , rcuStateMyCounter
+                       , rcuStateThreadCountersV } = do
+  -- Get this thread's counter.
+  mc <- readCounter rcuStateMyCounter
+  storeLoadBarrier
+  -- If this thread is not offline already, take it offline.
+  when (mc /= offline) $ writeCounter rcuStateMyCounter offline
+
+  -- Loop through thread counters, waiting for online threads to catch up
+  -- and skipping offline threads.  
+  -- TODO: urcu acquires rcu_gp_lock here, and holds it until the writer has 
+  -- updated the global counter AND finished waiting for readers. I think we may be able
+  -- to avoid holding the lock while waiting for readers as long as we
+  -- allow thread counters to exceed gc' (this is the case currently).     
+  -- Maybe urcu holds the lock to prevent multiple readers from busy-waiting
+  -- on the same shared array?  All they're doing is loading, so I'm not sure
+  -- why that would be a bad thing...  This issue, (and having a lock here at all)
+  -- is moot until we remove the big lock around write-side critical sections.
+  -- This is worth pinging Mathieu about.
+  -- So, TODO: Remove this lock, add a storeLoadBarrier after rcuStateMyCounter update.
+  gc' <- withMVar rcuStateThreadCountersV $ \ threadCounters -> do
+    -- Increment the global counter.
+    gc' <- incCounter rcuStateGlobalCounter
+    writeBarrier
+    -- Wait for each online reader to copy the new global counter.
+    let waitForThread i threadCounter = do
+          tc <- readCounter threadCounter
+          when (tc /= offline && tc < gc') $ do 
+            -- urcu puts the thread on a futex wait queue once per Int32 overflow
+            -- in this loop.  
+            threadDelay 1    -- TODO: Busy-wait for a while before sleeping.
+
+            storeLoadBarrier -- This works on all systems, even those with 
+                             -- incoherent caches, but slows down writers 
+                             -- unnecessarily on cache-coherent systems.  
+                             -- TODO: On cache-coherent systems, 
+                             -- figure out how to make GHC emit e.g. "rep; nop"
+                             -- to tell the CPU we're in a busy-wait loop.  
+                             -- urcu uses "caa_cpu_relax()" decorated with a compiler
+                             -- reordering barrier in this case.
+            waitForThread (i + 1) threadCounter
+    forM_ threadCounters (waitForThread 0)
+    return gc'
+  when (mc /= offline) $ writeCounter rcuStateMyCounter gc'
+  storeLoadBarrier
+
+--------------------------------------------------------------------------------
+-- * RCU Context
+--------------------------------------------------------------------------------
+
+-- | This is an RCU computation. It can use 'forking' and 'joining' to form
+-- new threads, and then you can use 'reading' and 'writing' to run classic
+-- read-side and write-side RCU computations. Writers are
+-- serialized using an MVar, readers are able to proceed while writers are
+-- updating.
+newtype RCU s a = RCU { unRCU :: RCUState -> IO a }
+  deriving Functor
+
+instance Applicative (RCU s) where
+  pure = return
+  (<*>) = ap
+
+instance Monad (RCU s) where
+  return a = RCU $ \ _ -> return a
+  RCU m >>= f = RCU $ \s -> do
+    a <- m s
+    unRCU (f a) s
+
+instance MonadNew (SRef s) (RCU s) where
+  newSRef a = RCU $ \_ -> SRef <$> newSRefIO a
+
+-- | This is a basic 'RCU' thread. It may be embellished when running in a more
+-- exotic context.
+data RCUThread s a = RCUThread
+  { rcuThreadId  :: {-# UNPACK #-} !ThreadId
+  , rcuThreadVar :: {-# UNPACK #-} !(MVar a)
+  }
+
+instance MonadRCU (SRef s) (RCU s) where
+  type Reading (RCU s) = ReadingRCU s
+  type Writing (RCU s) = WritingRCU s
+  type Thread (RCU s) = RCUThread s
+  forking (RCU m) = RCU $ \ s@RCUState { rcuStateGlobalCounter 
+                                       , rcuStateThreadCountersV
+                                       , rcuStateWriterLockV } -> do
+    -- Create an MVar the new thread can use to return a result.
+    result <- newEmptyMVar
+
+    -- Create a counter for the new thread, and add it to the list.
+    threadCounter <- newCounter
+    -- Wouldn't <$$> be nice here...
+    modifyMVar_ rcuStateThreadCountersV $ return . (threadCounter :)
+
+    -- Spawn the new thread, whose return value goes in @result@.
+    tid <- forkIO $ do
+      x <- m $ s { rcuStateMyCounter = threadCounter }
+      putMVar result x
+
+      -- After the new thread has completed, mark its counter as offline
+      -- and remove this counter from the list writers poll.
+      writeBarrier
+      writeCounter threadCounter offline
+      modifyMVar_ rcuStateThreadCountersV $ return . delete threadCounter
+    return (RCUThread tid result)
+  {-# INLINE forking #-}
+
+  joining (RCUThread _ m) = RCU $ \ _ -> readMVar m
+  {-# INLINE joining #-}
+
+  reading (ReadingRCU m) = RCU $ \ s@RCUState { rcuStateMyCounter
+                                              , rcuStateGlobalCounter } -> do
+    mc <- readCounter rcuStateMyCounter
+    -- If this thread was offline, take a snapshot of the global counter so
+    -- writers will wait.
+    when (mc == offline) $ do
+      writeCounter rcuStateMyCounter =<< readCounter rcuStateGlobalCounter   
+      -- Make sure that the counter goes online before reads begin.
+      storeLoadBarrier
+    
+    -- Run a read-side critical section.
+    x <- m s
+    
+    -- Announce a quiescent state after the read-side critical section.
+    -- TODO: Make this tunable/optional.
+    storeLoadBarrier
+    writeCounter rcuStateMyCounter =<< readCounter rcuStateGlobalCounter
+    storeLoadBarrier
+    
+    -- Return the result of the read-side critical section.
+    return x
+  {-# INLINE reading #-}
+
+  writing (WritingRCU m) = RCU $ \ s@RCUState { rcuStateWriterLockV } -> do
+    -- Acquire the writer-serializing lock.
+    takeMVar rcuStateWriterLockV
+
+    -- Run a write-side critical section.
+    x <- m s
+
+    -- Guarantee that writes in this critical section happen before writes in
+    -- subsequent critical sections.
+    synchronizeIO s
+
+    -- Release the writer-serializing lock.
+    putMVar rcuStateWriterLockV ()
+    return x
+  {-# INLINE writing #-}
+
+instance MonadIO (RCU s) where
+  liftIO m = RCU $ \ _ -> m
+  {-# INLINE liftIO #-}
+
+-- | Run an RCU computation.
+runRCU :: (forall s. RCU s a) -> IO a
+runRCU m = do
+  unRCU m =<< RCUState <$> newCounter <*> newCounter <*> newMVar [] <*> newMVar ()
+{-# INLINE runRCU #-}

--- a/src/Control/Concurrent/RCU/STM/Internal.hs
+++ b/src/Control/Concurrent/RCU/STM/Internal.hs
@@ -11,9 +11,10 @@
 {-# OPTIONS_HADDOCK not-home #-}
 -----------------------------------------------------------------------------
 -- |
--- Copyright   :  (C) 2015 Edward Kmett
+-- Copyright   :  (C) 2015 Edward Kmett and Ted Cooper
 -- License     :  BSD-style (see the file LICENSE)
 -- Maintainer  :  Edward Kmett <ekmett@gmail.com>
+--                Ted Cooper <anthezium@gmail.com>
 -- Stability   :  experimental
 -- Portability :  non-portable
 --


### PR DESCRIPTION
- Added a MonadicRP-style QSBR RCU implementation in Control.Concurrent.RCU.QSBR.
- Added primitive and atomic-primops dependencies.
- Updated README to include QSBR, clarified relationship to Howard and Walpole.
- Added MoveStringQSBR and MoveStringSTM examples to demonstrate that that STM and
  QSBR synchronize implementations have different semantics.
- Added my name to the project.
